### PR TITLE
Change the API endpoint for the getRooms method

### DIFF
--- a/src/chatkit.ts
+++ b/src/chatkit.ts
@@ -202,7 +202,7 @@ export default class Chatkit {
 
     return this.apiInstance.request({
       method: 'GET',
-      path: `/rooms`,
+      path: `/users/${userId}/rooms`,
       jwt: jwt.token,
     }).then((res) => {
       return JSON.parse(res.body);


### PR DESCRIPTION
Calling /rooms results in the getRooms method results in the wrong result for the given userId. With the proposed change, the getRooms method works as expected.