### PR TITLE
Renames package to live under pusher org

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pusher-chatkit-server",
+  "name": "@pusher/chatkit-server",
   "description": "Pusher Chatkit server library",
   "version": "0.10.0",
   "main": "./target/index.js",


### PR DESCRIPTION
This will mean that the library would be available under `@pusher/chatkit-server` on NPM. It will still be available under `pusher-chatkit-server` but the plan is to move everything over to the org eventually.