### PR TITLE
Use test config the same way as JS client does

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ target/
 
 
 # End of https://www.gitignore.io/api/node
+tests/config/production.ts
+tests/config/staging.ts
+tests/config/development.ts

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
 language: node_js
 node_js:
   - "node"
+
+before_script:
+  - yarn
+  - cp tests/config/example.ts tests/config/production.ts
+  - sed -i -e "s|your:instance:locator|$INSTANCE_LOCATOR|g" tests/config/production.ts
+  - sed -i -e "s|your:key|$INSTANCE_KEY|g" tests/config/production.ts
+
+script:
+  - yarn test

--- a/tests/config/example.ts
+++ b/tests/config/example.ts
@@ -1,0 +1,4 @@
+/* eslint-disable */
+
+export const INSTANCE_KEY = "your:key"
+export const INSTANCE_LOCATOR = "your:instance:locator"

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -8,27 +8,20 @@ import {
   ErrorResponse,
 } from "../src/index"
 
+import {
+  INSTANCE_LOCATOR,
+  INSTANCE_KEY,
+} from "./config/production"
+
 const TEST_TIMEOUT = 15 * 1000
 const DELETE_RESOURCES_PAUSE = 0
 
 let instanceLocator: string
 let key: string
 
-if (process.env.INSTANCE_LOCATOR) {
-  instanceLocator = process.env.INSTANCE_LOCATOR
-} else {
-  throw Error("missing config INSTANCE_LOCATOR")
-}
-
-if (process.env.INSTANCE_KEY) {
-  key = process.env.INSTANCE_KEY
-} else {
-  throw Error("missing config INSTANCE_KEY")
-}
-
 let clientConfig = {
-  instanceLocator,
-  key,
+  instanceLocator: INSTANCE_LOCATOR,
+  key: INSTANCE_KEY,
 }
 
 // README


### PR DESCRIPTION
### What?

Keep test config in .git/npm ignored files so it persists between shell sessions. Like chatkit-client-js does.

### Why?

I'm tired of re-exporting env vars.

----

- [ ] CHANGELOG updated if relevant?
