### PR TITLE
be explicit about exactly what we're serializing

### DIFF
--- a/src/chatkit.ts
+++ b/src/chatkit.ts
@@ -628,10 +628,10 @@ export default class Chatkit {
       su: true,
     })
 
-    const { initialId, ...optionsMinusInitialId } = options
-    let qs: FetchMessagesPayload = optionsMinusInitialId
-    if (initialId) {
-      qs["initial_id"] = initialId
+    let qs: FetchMessagesPayload = {
+      direction: options.direction,
+      limit: options.limit,
+      initial_id: options.initialId,
     }
 
     return options.serverInstance


### PR DESCRIPTION
We were sending a load of unnecessary stuff in the query params here. Can add this to my list of "typescript ain't gonna save you" examples...