### PR TITLE
Bump min lodash version to 4.17.13 due to security concerns

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "got": "^9.6.0",
     "jsonwebtoken": "^8.3.0"
   },
+  "resolutions": {
+    "**/**/lodash": "^4.17.13"
+  },
   "devDependencies": {
     "@types/tape": "^4.2.32",
     "babel-core": "^6.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1722,10 +1722,10 @@ lodash.toarray@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
   integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
 
-lodash@4.17.11, lodash@^4.17.10, lodash@^4.17.4:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+lodash@4.17.11, lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.4:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-update@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Why?

```
CVE-2019-10744 More information

high severity
Vulnerable versions: < 4.17.13
Patched version: 4.17.13
Affected versions of lodash are vulnerable to Prototype Pollution.
The function defaultsDeep could be tricked into adding or modifying properties of Object.prototype using a constructor payload.
```

For more on how `resolutions` work refer to: https://yarnpkg.com/lang/en/docs/selective-version-resolutions/


----

- [ ] CHANGELOG updated if relevant?
