### PR TITLE
change truthy check on isPrivate to check undefined/null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-server-node/compare/2.1.0...HEAD)
 
+- Fix `updateRoom` privacy not updating when `isPrivacy` value is `false`
+
 ## [2.1.0](https://github.com/pusher/chatkit-server-node/compare/2.0.1...2.1.0)
 
 ### Additions

--- a/src/chatkit.ts
+++ b/src/chatkit.ts
@@ -743,7 +743,7 @@ export default class Chatkit {
     if (options.pushNotificationTitleOverride) {
       body.push_notification_title_override = options.pushNotificationTitleOverride
     }
-    if (options.isPrivate) {
+    if (options.isPrivate != null) {
       body.private = options.isPrivate
     }
     if (options.customData) {


### PR DESCRIPTION
### What?

- changes truthy check on `options.isPrivate` on the `updateRoom` method.

```js
if (options.isPrivate != null) {
  body.private = options.isPrivate
}
// instead of
if (options.isPrivate) {
  body.private = options.isPrivate
}
```

### Why?

Because if the `options.isPrivate` value is false it does not get added to the body.

----

- [x] CHANGELOG updated if relevant? 